### PR TITLE
jQuery 1.6 compatibility

### DIFF
--- a/lib/jquery.pageless.js
+++ b/lib/jquery.pageless.js
@@ -173,7 +173,7 @@
                loading(FALSE);
                // if there is a complete callback we call it
                if (settings.complete) settings.complete.call();
-           });
+           }, 'html');
     }
   };
 })(jQuery);


### PR DESCRIPTION
Adding dataType of `html` to the $.get call to make it work with jQuery 1.6.x
