### PR TITLE
Allow scrape function to access full result from ajax request

### DIFF
--- a/lib/jquery.pageless.js
+++ b/lib/jquery.pageless.js
@@ -116,6 +116,7 @@
         $('#pageless-loader .msg').html(opts.loaderMsg);
       }
     }
+    loading(isLoading);
   };
   
   //

--- a/lib/jquery.pageless.js
+++ b/lib/jquery.pageless.js
@@ -167,8 +167,8 @@
       // finally ajax query
       $.get( settings.url
            , settings.params
-           , function (data) {
-               $.isFunction(settings.scrape) ? settings.scrape(data) : data;
+           , function (data, text, xhr) {
+               $.isFunction(settings.scrape) ? settings.scrape(data, xhr) : data;
                loader ? loader.before(data) : element.append(data);
                loading(FALSE);
                // if there is a complete callback we call it


### PR DESCRIPTION
This enabled me to not have to load any part of the collection at all when the page is loaded, and then when clicking a specific element, I kick off pageless with a currentPage of 0 and totalPages of 1.  It immediately does an ajax request (because the container's height is 0), and then in the response to that request I update how many total pages there actually are using the scrape callback.
